### PR TITLE
feat(proxy): implement v0.2 anthropic API proxy slice

### DIFF
--- a/.ai-factory/plans/feature-002-core-proxy.md
+++ b/.ai-factory/plans/feature-002-core-proxy.md
@@ -1,0 +1,103 @@
+# Implementation Plan: 002-core-proxy (v0.2)
+
+Branch: feature/002-core-proxy
+Created: 2026-03-15
+
+## Settings
+- Testing: yes
+- Logging: verbose
+- Docs: yes
+
+## Roadmap Linkage
+Milestone: "002-core-proxy (v0.2)"
+Rationale: Delivers the first provider-aware API proxy slice required by `core#2` before generalized proxy work in `core#8`.
+
+## Research Context
+Source: workspace `.ai-factory/RESEARCH.md` (Active Summary)
+
+Goal:
+- Consolidate artifacts and GitHub scope for `v0.2 / 002-core-proxy` and convert them into an executable plan.
+
+Constraints:
+- Keep transport proxy scope separate from passive collectors.
+- Preserve auth boundary: `client -> core` token is separate from `core -> provider` keys.
+- Implement only first provider-aware `API proxy (L7)` slice; defer `HTTP proxy / CONNECT` to `2.1`.
+
+Decisions:
+- Source of truth: roadmap and architecture docs plus `core#2` comment clarifying scope boundaries.
+- `core#2` is the implementation anchor for this plan.
+- `core#3` and `core#8` remain adjacent but out-of-scope for this delivery slice.
+
+Open questions:
+- Minimal diagnostics contract for proxy mode in API and CLI.
+- Required Anthropic/Claude fields for first accounting extraction.
+
+## Commit Plan
+- **Commit 1** (after tasks 1-3): `feat(proxy): add v0.2 proxy contracts, config, and HTTP endpoints`
+- **Commit 2** (after tasks 4-6): `feat(proxy): add anthropic forwarding, accounting, and proxy status diagnostics`
+- **Commit 3** (after tasks 7-8): `feat(cli): expose proxy diagnostics and doctor integration`
+- **Commit 4** (after tasks 9-10): `test+docs(proxy): expand proxy coverage and finalize release-quality checks`
+
+## Tasks
+
+### Phase 1: Contracts and scaffolding
+- [x] Task 1: Define v0.2 proxy contract surface and config shape.
+  Files: `api/openapi/v1/openapi.yaml`, `config/config.example.json`, `internal/config/config.go`, `internal/config/config_test.go`.
+  Deliverables: add `API proxy (L7)` endpoint contracts for Anthropic forwarding and proxy diagnostics (`/api/v1/proxy/status`), and define proxy config fields (enabled flag, upstream base URL override, timeout).
+  Logging requirements: log proxy config resolution at `DEBUG` (`component=config`, fields for enabled mode, base URL, timeout), and log invalid proxy config values at `WARN` with stable error code mapping.
+
+- [x] Task 2: Create proxy module skeleton for provider-aware API proxy (`internal/proxy/api`) and diagnostics state.
+  Files: `internal/proxy/api/*.go` (new), optional shared types in `internal/domain` if needed.
+  Deliverables: service interface for forward/status flows, upstream client abstraction, and in-memory diagnostics model for last successful/failed proxy attempts.
+  Logging requirements: log request lifecycle checkpoints at `DEBUG` (`request_id`, provider, model hint, endpoint), upstream call start/finish at `INFO`, and upstream/network failures at `ERROR` with provider metadata.
+  Depends on: Task 1.
+
+- [x] Task 3: Add auth-gated proxy HTTP endpoint registration and input validation in core API layer.
+  Files: `internal/api/handlers/handlers.go`, `internal/api/server/server.go`, `internal/api/server/server_test.go`.
+  Deliverables: register forward and status routes, enforce method/content validation, and keep handlers thin by delegating provider-specific logic to proxy module.
+  Logging requirements: log proxy endpoint invocation at `INFO`, method/path validation failures at `WARN`, and policy/auth rejections at `WARN` with `request_id` and route.
+  Depends on: Task 1, Task 2.
+
+### Phase 2: Core proxy behavior and CLI surface
+- [x] Task 4: Implement Anthropic-first upstream forwarding and response passthrough for the v0.2 API proxy path.
+  Files: `internal/proxy/api/*.go`, `internal/api/handlers/handlers.go`, `internal/errors/codes.go` (if new proxy-specific codes are required).
+  Deliverables: build upstream request with server-side Anthropic key, forward payload/headers safely, and map upstream failures to stable core error envelopes without leaking secrets.
+  Logging requirements: log upstream latency, status code, retry/no-retry decision, and normalized failure envelope; include `provider=anthropic` and `operation=proxy_forward` in all proxy flow logs.
+  Depends on: Task 2, Task 3.
+
+- [x] Task 5: Extract usage/accounting metadata from proxied responses and persist via shared usage pipeline.
+  Files: `internal/proxy/api/*.go`, `internal/storage/store.go` (only if persistence helpers need extension), `internal/domain/models.go` (only if metadata model requires extension).
+  Deliverables: parse provider usage fields from proxy response path, normalize to current usage model, and degrade gracefully if extraction fails while keeping proxy response path functional.
+  Logging requirements: log extracted accounting fields at `DEBUG` (tokens/cost/error class), persistence success at `INFO`, and partial extraction/persistence degradation at `WARN` without corrupting totals.
+  Depends on: Task 4.
+
+- [x] Task 6: Implement proxy diagnostics/status API behavior and expose transport-safe metadata.
+  Files: `internal/proxy/api/*.go`, `internal/api/handlers/handlers.go`, `internal/api/handlers/handlers_test.go`.
+  Deliverables: return proxy enabled/configured state, last upstream status, last error code/message, and timestamps without exposing provider secrets or payload content.
+  Logging requirements: log diagnostics reads at `DEBUG`, state transitions at `INFO`, and stale/invalid status state at `WARN`.
+  Depends on: Task 2, Task 4, Task 5.
+
+- [x] Task 7: Extend CLI with proxy diagnostics and health visibility for v0.2.
+  Files: `internal/cli/commands.go`, `internal/cli/httpclient/client.go`, `internal/cli/doctor/doctor.go`, `internal/cli/cli_test.go`, `internal/cli/doctor/doctor_test.go`.
+  Deliverables: add proxy diagnostics command surface and include proxy checks in doctor output using the new status endpoint contract.
+  Logging requirements: log proxy check start/finish and duration at `INFO`, response parsing details at `DEBUG`, and user-facing diagnostic failures at `ERROR` with mapped stable error codes.
+  Depends on: Task 6.
+
+- [x] Task 8: Harden proxy flow for security and observability boundaries.
+  Files: `internal/proxy/api/*.go`, `internal/api/middleware/logging.go` (only if log field extensions are needed), `test/security/security_test.go`.
+  Deliverables: ensure proxy logs never include provider keys or raw sensitive payload fragments, and add security assertions for redaction and auth-gated provider-spending paths.
+  Logging requirements: log redaction decisions at `DEBUG` (without secret values), auth boundary violations at `WARN`, and security-relevant execution failures at `ERROR`.
+  Depends on: Task 4, Task 5, Task 6.
+
+### Phase 3: Verification and documentation
+- [x] Task 9: Add comprehensive test coverage for proxy endpoint, status diagnostics, auth behavior, and accounting persistence.
+  Files: `internal/api/handlers/handlers_test.go`, `internal/api/server/server_test.go`, `test/integration/*proxy*_test.go` (new), `test/perf/*proxy*_test.go` (new if needed), plus proxy module tests under `internal/proxy/api`.
+  Deliverables: cover success/error/timeout paths, remote-mode auth enforcement, local-loopback behavior, diagnostics endpoint behavior, and proxy latency budget checks.
+  Logging requirements: test fixtures should assert stable structured fields in critical logs where behavior relies on auditability (auth rejection, upstream error, accounting write path).
+  Depends on: Task 7, Task 8.
+
+- [x] Task 10: Update contracts/docs and run release-quality gates for v0.2 proxy slice.
+  Files: `api/openapi/v1/openapi.yaml`, `README.md`, any proxy notes required under `.ai-factory` in this repo.
+  Deliverables: synchronize API docs with implemented behavior, document proxy diagnostics and auth expectations, and run `go test ./...`, `go build ./cmd/quiverkeep`, `go vet ./...`, and repository lint checks (or document if lint target is not yet defined) as mandatory completion gates.
+  Logging requirements: document expected log keys and levels for proxy operations, including minimum observability fields required in production.
+  Depends on: Task 9.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ Core Base implementation is present and runnable.
     - `GET /api/v1/limits`
     - `GET /api/v1/subscriptions`
     - `GET /api/v1/providers`
+    - `POST /api/v1/proxy/anthropic/messages`
+    - `GET /api/v1/proxy/status`
 - Thin CLI commands:
-    - `serve`, `status`, `usage`, `limits`, `config show`, `config path`, `doctor`, `version`
+    - `serve`, `status`, `usage`, `limits`, `proxy status`, `config show`, `config path`, `doctor`, `version`
 - Structured logging with configurable `LOG_LEVEL` and JSON output.
 - Contract/integration/perf/security tests (`go test ./...`).
 
@@ -54,14 +56,24 @@ In another terminal:
 Set-Location D:\Projects\aifhub\quiverkeep\quiverkeep-core
 go run .\cmd\quiverkeep status
 go run .\cmd\quiverkeep usage --json
+go run .\cmd\quiverkeep proxy status --json
 go run .\cmd\quiverkeep doctor --json
 ```
+
+## Proxy Mode (v0.2)
+
+- `POST /api/v1/proxy/anthropic/messages` forwards Anthropic Messages API payloads through core.
+- Upstream non-success and timeout outcomes are mapped to stable core errors (`PROXY_UPSTREAM_ERROR`, `PROXY_TIMEOUT`).
+- Proxy diagnostics are exposed through `GET /api/v1/proxy/status`.
+- Provider-spending proxy calls require core bearer auth even in loopback mode.
 
 ## Logging Policy
 
 - Structured logs only (JSON).
 - Required keys in operational flows: `component`, `operation`, `request_id`, `duration_ms`, `error_code` when
   applicable.
+- Proxy operations must include: `provider`, `operation=proxy_forward|proxy_usage|proxy_status`, `retry_decision`,
+  and upstream `status` where applicable.
 - Levels:
     - `DEBUG` for detailed flow and override resolution.
     - `INFO` for lifecycle and successful operations.
@@ -76,6 +88,21 @@ go run .\cmd\quiverkeep doctor --json
 - `PORT_IN_USE`: run `quiverkeep serve --port 9000`.
 - `STORAGE_LOCK_ERROR`: check whether another core instance is active; stale lock is auto-cleaned.
 - `UNAUTHORIZED`: verify `QUIVERKEEP_TOKEN` / `Authorization: Bearer ...` policy for remote mode.
+- `PROXY_DISABLED` / `PROXY_NOT_CONFIGURED`: enable proxy mode and set `ANTHROPIC_API_KEY`.
+- `PROXY_UPSTREAM_ERROR` / `PROXY_TIMEOUT`: inspect proxy logs and `/api/v1/proxy/status` diagnostics.
+
+## Quality Gates
+
+Required completion gates for this repository:
+
+```powershell
+go test ./...
+go build ./cmd/quiverkeep
+go vet ./...
+```
+
+Lint target is not defined yet in this repository (`Makefile` / `Taskfile` is absent), so lint checks are currently
+documented as pending automation.
 
 ## Repository Boundary Runbook
 

--- a/api/openapi/v1/openapi.yaml
+++ b/api/openapi/v1/openapi.yaml
@@ -48,3 +48,114 @@ paths:
       responses:
         "200":
           description: Provider status payload
+  /api/v1/proxy/anthropic/messages:
+    post:
+      summary: Anthropic API proxy (L7)
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Anthropic `/v1/messages` request payload passthrough.
+              additionalProperties: true
+      responses:
+        "200":
+          description: Proxied Anthropic response payload
+        "400":
+          description: Validation error (invalid method/content-type/body)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "401":
+          description: Core auth error (missing/invalid bearer token)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "502":
+          description: Upstream provider failure mapped to stable core error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "503":
+          description: Proxy is disabled or provider key is not configured
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "504":
+          description: Upstream provider timeout mapped to stable core error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+  /api/v1/proxy/status:
+    get:
+      summary: Proxy diagnostics status
+      responses:
+        "200":
+          description: Proxy status payload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProxyStatusResponse"
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: token
+  schemas:
+    ErrorEnvelope:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          description: Stable error code
+        message:
+          type: string
+          description: Human-readable error message
+    ProxyStatusResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProxyStatusItem"
+    ProxyStatusItem:
+      type: object
+      required:
+        - provider
+        - enabled
+        - configured
+      properties:
+        provider:
+          type: string
+          example: anthropic
+        enabled:
+          type: boolean
+        configured:
+          type: boolean
+        last_attempt_at:
+          type: string
+          format: date-time
+        last_success_at:
+          type: string
+          format: date-time
+        last_error_code:
+          type: string
+          example: PROXY_TIMEOUT
+        last_error_message:
+          type: string
+        last_upstream_code:
+          type: integer

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -17,6 +17,14 @@
       "token": ""
     }
   },
+  "proxy": {
+    "enabled": false,
+    "anthropic": {
+      "base_url": "https://api.anthropic.com",
+      "version": "2023-06-01",
+      "timeout_seconds": 30
+    }
+  },
   "storage": {
     "path": ""
   },

--- a/internal/api/errors/envelope.go
+++ b/internal/api/errors/envelope.go
@@ -35,6 +35,12 @@ func toHTTPStatus(code qerrors.Code) int {
 		return http.StatusBadRequest
 	case qerrors.CodePortInUse:
 		return http.StatusConflict
+	case qerrors.CodeProxyDisabled, qerrors.CodeProxyNotConfigured:
+		return http.StatusServiceUnavailable
+	case qerrors.CodeProxyUpstreamError:
+		return http.StatusBadGateway
+	case qerrors.CodeProxyTimeout:
+		return http.StatusGatewayTimeout
 	default:
 		return http.StatusInternalServerError
 	}

--- a/internal/api/handlers/handlers.go
+++ b/internal/api/handlers/handlers.go
@@ -2,33 +2,40 @@ package handlers
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
 	apierrors "github.com/ichinya/quiverkeep-core/internal/api/errors"
+	"github.com/ichinya/quiverkeep-core/internal/api/middleware"
 	"github.com/ichinya/quiverkeep-core/internal/config"
 	"github.com/ichinya/quiverkeep-core/internal/domain"
 	qerrors "github.com/ichinya/quiverkeep-core/internal/errors"
 	"github.com/ichinya/quiverkeep-core/internal/logging"
+	proxyapi "github.com/ichinya/quiverkeep-core/internal/proxy/api"
 	"github.com/ichinya/quiverkeep-core/internal/storage"
 	"github.com/ichinya/quiverkeep-core/internal/version"
 )
 
+const maxProxyBodyBytes = 2 * 1024 * 1024
+
 type API struct {
-	store     *storage.Store
-	cfg       config.Config
-	startedAt time.Time
-	logger    *logging.Logger
+	store          *storage.Store
+	cfg            config.Config
+	startedAt      time.Time
+	logger         *logging.Logger
+	anthropicProxy *proxyapi.AnthropicProxy
 }
 
 func New(store *storage.Store, cfg config.Config, logger *logging.Logger) *API {
 	return &API{
-		store:     store,
-		cfg:       cfg,
-		startedAt: time.Now().UTC(),
-		logger:    logger,
+		store:          store,
+		cfg:            cfg,
+		startedAt:      time.Now().UTC(),
+		logger:         logger,
+		anthropicProxy: proxyapi.NewAnthropicProxy(cfg, logger, store),
 	}
 }
 
@@ -38,6 +45,8 @@ func (a *API) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/v1/limits", a.limits)
 	mux.HandleFunc("/api/v1/subscriptions", a.subscriptions)
 	mux.HandleFunc("/api/v1/providers", a.providers)
+	mux.HandleFunc("/api/v1/proxy/anthropic/messages", a.proxyAnthropicMessages)
+	mux.HandleFunc("/api/v1/proxy/status", a.proxyStatus)
 }
 
 func (a *API) status(w http.ResponseWriter, r *http.Request) {
@@ -129,6 +138,142 @@ func (a *API) providers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{"items": providers})
+}
+
+func (a *API) proxyAnthropicMessages(w http.ResponseWriter, r *http.Request) {
+	requestID := middleware.RequestIDFromContext(r.Context())
+	a.logger.Info("proxy endpoint invocation",
+		"component", "api",
+		"operation", "proxy_forward",
+		"provider", "anthropic",
+		"request_id", requestID,
+		"method", r.Method,
+		"path", r.URL.Path,
+	)
+
+	if r.Method != http.MethodPost {
+		a.logger.Warn("proxy method not allowed",
+			"component", "api",
+			"operation", "proxy_forward",
+			"provider", "anthropic",
+			"request_id", requestID,
+			"method", r.Method,
+			"path", r.URL.Path,
+		)
+		apierrors.Write(w, qerrors.New(qerrors.CodeValidationFailed, "method not allowed"))
+		return
+	}
+
+	contentType := strings.TrimSpace(strings.ToLower(r.Header.Get("Content-Type")))
+	if contentType != "" && !strings.HasPrefix(contentType, "application/json") {
+		a.logger.Warn("proxy content-type validation failed",
+			"component", "api",
+			"operation", "proxy_forward",
+			"provider", "anthropic",
+			"request_id", requestID,
+			"content_type", contentType,
+		)
+		apierrors.Write(w, qerrors.New(qerrors.CodeValidationFailed, "content-type must be application/json"))
+		return
+	}
+
+	limited := io.LimitReader(r.Body, maxProxyBodyBytes+1)
+	body, err := io.ReadAll(limited)
+	if err != nil {
+		a.logger.Warn("proxy request body read failed",
+			"component", "api",
+			"operation", "proxy_forward",
+			"provider", "anthropic",
+			"request_id", requestID,
+		)
+		apierrors.Write(w, qerrors.Wrap(qerrors.CodeValidationFailed, "failed to read request body", err))
+		return
+	}
+	if len(body) == 0 {
+		a.logger.Warn("proxy request body is empty",
+			"component", "api",
+			"operation", "proxy_forward",
+			"provider", "anthropic",
+			"request_id", requestID,
+		)
+		apierrors.Write(w, qerrors.New(qerrors.CodeValidationFailed, "request body is required"))
+		return
+	}
+	if len(body) > maxProxyBodyBytes {
+		a.logger.Warn("proxy request body exceeds size limit",
+			"component", "api",
+			"operation", "proxy_forward",
+			"provider", "anthropic",
+			"request_id", requestID,
+			"body_size", len(body),
+			"max_body_size", maxProxyBodyBytes,
+		)
+		apierrors.Write(w, qerrors.New(qerrors.CodeValidationFailed, "request body exceeds size limit"))
+		return
+	}
+
+	response, err := a.anthropicProxy.Forward(r.Context(), proxyapi.ForwardRequest{
+		Payload:       body,
+		AnthropicBeta: strings.TrimSpace(r.Header.Get("Anthropic-Beta")),
+		RequestID:     requestID,
+	})
+	if err != nil {
+		a.logger.Error("proxy forward failed",
+			"component", "api",
+			"operation", "proxy_forward",
+			"provider", "anthropic",
+			"request_id", requestID,
+			"error", err,
+		)
+		apierrors.Write(w, err)
+		return
+	}
+
+	for key, values := range response.Headers {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	if strings.TrimSpace(w.Header().Get("Content-Type")) == "" {
+		w.Header().Set("Content-Type", "application/json")
+	}
+	w.WriteHeader(response.StatusCode)
+	_, _ = w.Write(response.Body)
+
+	a.logger.Info("proxy forward response passthrough",
+		"component", "api",
+		"operation", "proxy_forward",
+		"provider", "anthropic",
+		"request_id", requestID,
+		"status", response.StatusCode,
+	)
+}
+
+func (a *API) proxyStatus(w http.ResponseWriter, r *http.Request) {
+	requestID := middleware.RequestIDFromContext(r.Context())
+	if r.Method != http.MethodGet {
+		a.logger.Warn("proxy status method not allowed",
+			"component", "api",
+			"operation", "proxy_status",
+			"request_id", requestID,
+			"method", r.Method,
+			"path", r.URL.Path,
+		)
+		apierrors.Write(w, qerrors.New(qerrors.CodeValidationFailed, "method not allowed"))
+		return
+	}
+
+	a.logger.Debug("proxy diagnostics endpoint read",
+		"component", "api",
+		"operation", "proxy_status",
+		"request_id", requestID,
+		"path", r.URL.Path,
+	)
+
+	status := a.anthropicProxy.Status()
+	writeJSON(w, http.StatusOK, map[string]any{
+		"items": []proxyapi.Status{status},
+	})
 }
 
 func parseUsageFilter(r *http.Request) (domain.UsageFilter, error) {

--- a/internal/api/handlers/handlers_test.go
+++ b/internal/api/handlers/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -67,13 +68,181 @@ func TestProvidersEndpoint(t *testing.T) {
 	}
 }
 
+func TestProxyStatusEndpoint(t *testing.T) {
+	t.Parallel()
+
+	api, cleanup := newTestAPI(t)
+	defer cleanup()
+
+	mux := http.NewServeMux()
+	api.Register(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/proxy/status", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status for /proxy/status: %d", rec.Code)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("invalid proxy status response: %v", err)
+	}
+	if _, ok := payload["items"]; !ok {
+		t.Fatalf("proxy status response missing items")
+	}
+}
+
+func TestAnthropicProxyForwardAndUsagePersistence(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1","model":"claude-3-5-sonnet","usage":{"input_tokens":12,"output_tokens":7}}`))
+	}))
+	defer upstream.Close()
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = true
+	cfg.Proxy.Anthropic.BaseURL = upstream.URL
+	cfg.Providers.Anthropic.Key = "test-anthropic"
+
+	api, cleanup := newTestAPIWithConfig(t, cfg)
+	defer cleanup()
+
+	mux := http.NewServeMux()
+	api.Register(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/proxy/anthropic/messages", strings.NewReader(`{"model":"claude-3-5-sonnet"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected status for proxy forward: %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	items, err := api.store.ListUsage(context.Background(), domain.UsageFilter{Service: "anthropic"})
+	if err != nil {
+		t.Fatalf("list usage failed: %v", err)
+	}
+	if len(items) == 0 {
+		t.Fatalf("expected anthropic usage record to be persisted")
+	}
+	if items[0].TokensIn != 12 || items[0].TokensOut != 7 {
+		t.Fatalf("unexpected persisted usage totals: %+v", items[0])
+	}
+}
+
+func TestAnthropicProxyReturnsServiceUnavailableWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = false
+	cfg.Providers.Anthropic.Key = "test-anthropic"
+
+	api, cleanup := newTestAPIWithConfig(t, cfg)
+	defer cleanup()
+
+	mux := http.NewServeMux()
+	api.Register(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/proxy/anthropic/messages", strings.NewReader(`{"model":"claude-3-5-sonnet"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected status 503, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAnthropicProxyMapsUpstreamFailure(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"upstream_error"}}`))
+	}))
+	defer upstream.Close()
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = true
+	cfg.Proxy.Anthropic.BaseURL = upstream.URL
+	cfg.Providers.Anthropic.Key = "test-anthropic"
+
+	api, cleanup := newTestAPIWithConfig(t, cfg)
+	defer cleanup()
+
+	mux := http.NewServeMux()
+	api.Register(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/proxy/anthropic/messages", strings.NewReader(`{"model":"claude-3-5-sonnet"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected status 502, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAnthropicProxyMapsTimeoutFailure(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(1200 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1"}`))
+	}))
+	defer upstream.Close()
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = true
+	cfg.Proxy.Anthropic.BaseURL = upstream.URL
+	cfg.Proxy.Anthropic.TimeoutSeconds = 1
+	cfg.Providers.Anthropic.Key = "test-anthropic"
+
+	api, cleanup := newTestAPIWithConfig(t, cfg)
+	defer cleanup()
+
+	mux := http.NewServeMux()
+	api.Register(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/proxy/anthropic/messages", strings.NewReader(`{"model":"claude-3-5-sonnet"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("expected status 504, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
 func newTestAPI(t *testing.T) (*API, func()) {
 	t.Helper()
 
+	return newTestAPIWithConfig(t, config.Default())
+}
+
+func newTestAPIWithConfig(t *testing.T, cfg config.Config) (*API, func()) {
+	t.Helper()
+
 	tempDir := t.TempDir()
-	cfg := config.Default()
 	cfg.Storage.Path = filepath.Join(tempDir, "core.db")
-	cfg.Providers.OpenAI.Key = "test-openai"
+	if strings.TrimSpace(cfg.Providers.OpenAI.Key) == "" {
+		cfg.Providers.OpenAI.Key = "test-openai"
+	}
 	meta := config.Metadata{
 		ConfigDir: tempDir,
 		Path:      filepath.Join(tempDir, "config.json"),

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -14,15 +14,25 @@ func Auth(cfg config.Config, logger *logging.Logger, remoteMode bool) func(http.
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestID := RequestIDFromContext(r.Context())
+			proxySpendingPath := requiresTokenForProxySpend(r.URL.Path)
+			requiresToken := remoteMode || proxySpendingPath
 
-			if remoteMode && !cfg.HasToken() {
-				logger.Warn("remote mode requires token",
+			if requiresToken && !cfg.HasToken() {
+				reason := "remote_mode"
+				message := "token is required in remote mode"
+				if proxySpendingPath {
+					reason = "proxy_spend"
+					message = "token is required for proxy operations"
+				}
+
+				logger.Warn("request requires token but token is not configured",
 					"component", "api",
 					"operation", "auth",
 					"request_id", requestID,
 					"path", r.URL.Path,
+					"reason", reason,
 				)
-				apierrors.Write(w, qerrors.New(qerrors.CodeUnauthorized, "token is required in remote mode"))
+				apierrors.Write(w, qerrors.New(qerrors.CodeUnauthorized, message))
 				return
 			}
 
@@ -62,5 +72,15 @@ func Auth(cfg config.Config, logger *logging.Logger, remoteMode bool) func(http.
 
 			next.ServeHTTP(w, r)
 		})
+	}
+}
+
+func requiresTokenForProxySpend(path string) bool {
+	cleanPath := strings.TrimSpace(path)
+	switch cleanPath {
+	case "/api/v1/proxy/anthropic/messages":
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/api/server/server_test.go
+++ b/internal/api/server/server_test.go
@@ -45,6 +45,17 @@ func TestAuthMatrix(t *testing.T) {
 		}
 	})
 
+	t.Run("loopback_proxy_without_token_rejects", func(t *testing.T) {
+		cfg := config.Default()
+		handler := middleware.Auth(cfg, logger, false)(next)
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/proxy/anthropic/messages", nil)
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", rec.Code)
+		}
+	})
+
 	t.Run("token_with_valid_header_allows", func(t *testing.T) {
 		cfg := config.Default()
 		token := "secret"

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -15,6 +15,7 @@ func TestRootCommandHasExpectedSubcommands(t *testing.T) {
 		"status":  false,
 		"usage":   false,
 		"limits":  false,
+		"proxy":   false,
 		"config":  false,
 		"doctor":  false,
 		"version": false,
@@ -30,6 +31,33 @@ func TestRootCommandHasExpectedSubcommands(t *testing.T) {
 		if !found {
 			t.Fatalf("expected subcommand %s", name)
 		}
+	}
+}
+
+func TestProxyCommandHasStatusSubcommand(t *testing.T) {
+	t.Parallel()
+
+	root := buildRootCommand(context.Background(), &Options{})
+	var proxyFound bool
+	var hasStatus bool
+	for _, command := range root.Commands() {
+		if command.Name() == "proxy" {
+			proxyFound = true
+			for _, proxyCommand := range command.Commands() {
+				if proxyCommand.Name() == "status" {
+					hasStatus = true
+					break
+				}
+			}
+			break
+		}
+	}
+
+	if !proxyFound {
+		t.Fatalf("expected proxy command on root")
+	}
+	if !hasStatus {
+		t.Fatalf("expected proxy command to expose status subcommand")
 	}
 }
 

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -55,6 +55,7 @@ func buildRootCommand(ctx context.Context, opts *Options) *cobra.Command {
 	cmd.AddCommand(buildStatusCommand(ctx, opts))
 	cmd.AddCommand(buildUsageCommand(ctx, opts))
 	cmd.AddCommand(buildLimitsCommand(ctx, opts))
+	cmd.AddCommand(buildProxyCommand(ctx, opts))
 	cmd.AddCommand(buildConfigCommand(ctx, opts))
 	cmd.AddCommand(buildDoctorCommand(ctx, opts))
 	cmd.AddCommand(&cobra.Command{
@@ -142,6 +143,23 @@ func buildLimitsCommand(ctx context.Context, opts *Options) *cobra.Command {
 			return runReadCommand(ctx, opts, "/api/v1/limits", nil)
 		},
 	}
+}
+
+func buildProxyCommand(ctx context.Context, opts *Options) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "proxy",
+		Short: "Proxy diagnostics and operations via HTTP",
+	}
+
+	command.AddCommand(&cobra.Command{
+		Use:   "status",
+		Short: "Get proxy diagnostics via HTTP",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runReadCommand(ctx, opts, "/api/v1/proxy/status", nil)
+		},
+	})
+
+	return command
 }
 
 func buildConfigCommand(ctx context.Context, opts *Options) *cobra.Command {

--- a/internal/cli/doctor/doctor.go
+++ b/internal/cli/doctor/doctor.go
@@ -12,11 +12,13 @@ import (
 )
 
 type Report struct {
-	RepositoryPath string `json:"repository_path"`
-	WorkspacePath  string `json:"workspace_path"`
-	Branch         string `json:"branch"`
-	CoreRunning    bool   `json:"core_running"`
-	Message        string `json:"message"`
+	RepositoryPath       string `json:"repository_path"`
+	WorkspacePath        string `json:"workspace_path"`
+	Branch               string `json:"branch"`
+	CoreRunning          bool   `json:"core_running"`
+	ProxyStatusReachable bool   `json:"proxy_status_reachable"`
+	ProxyEnabled         bool   `json:"proxy_enabled"`
+	Message              string `json:"message"`
 }
 
 func Run(ctx context.Context, client *httpclient.Client, logger *logging.Logger) (Report, error) {
@@ -32,22 +34,86 @@ func Run(ctx context.Context, client *httpclient.Client, logger *logging.Logger)
 	}
 
 	var status map[string]any
+	logger.Info("doctor check start",
+		"component", "cli",
+		"operation", "doctor",
+		"check", "core_status",
+	)
 	if err := client.GetJSON(ctx, "/api/v1/status", nil, &status); err == nil {
 		report.CoreRunning = true
-		report.Message = "All checks passed"
+		logger.Debug("doctor core status parsed",
+			"component", "cli",
+			"operation", "doctor",
+			"check", "core_status",
+			"payload_keys", len(status),
+		)
+
+		var proxyStatus map[string]any
+		proxyStarted := time.Now()
+		logger.Info("doctor proxy check start",
+			"component", "cli",
+			"operation", "doctor",
+			"check", "proxy_status",
+		)
+		proxyErr := client.GetJSON(ctx, "/api/v1/proxy/status", nil, &proxyStatus)
+		if proxyErr == nil {
+			report.ProxyStatusReachable = true
+			report.ProxyEnabled = extractProxyEnabled(proxyStatus)
+			report.Message = "All checks passed"
+			logger.Debug("doctor proxy status parsed",
+				"component", "cli",
+				"operation", "doctor",
+				"check", "proxy_status",
+				"proxy_enabled", report.ProxyEnabled,
+				"payload_keys", len(proxyStatus),
+			)
+			logger.Info("doctor proxy check finish",
+				"component", "cli",
+				"operation", "doctor",
+				"check", "proxy_status",
+				"duration_ms", time.Since(proxyStarted).Milliseconds(),
+				"proxy_status_reachable", report.ProxyStatusReachable,
+				"proxy_enabled", report.ProxyEnabled,
+			)
+			logger.Info("doctor report generated",
+				"component", "cli",
+				"operation", "doctor",
+				"core_running", report.CoreRunning,
+				"proxy_status_reachable", report.ProxyStatusReachable,
+				"proxy_enabled", report.ProxyEnabled,
+				"duration_ms", time.Since(started).Milliseconds(),
+			)
+			return report, nil
+		}
+
+		report.Message = proxyErr.Error()
+		logger.Error("doctor proxy check failed",
+			"component", "cli",
+			"operation", "doctor",
+			"check", "proxy_status",
+			"duration_ms", time.Since(proxyStarted).Milliseconds(),
+			"error_code", qerrors.CodeOf(proxyErr),
+		)
 		logger.Info("doctor report generated",
 			"component", "cli",
 			"operation", "doctor",
 			"core_running", report.CoreRunning,
+			"proxy_status_reachable", report.ProxyStatusReachable,
 			"duration_ms", time.Since(started).Milliseconds(),
 		)
-		return report, nil
+		return report, proxyErr
 	} else {
 		report.Message = err.Error()
 		code := qerrors.CodeOf(err)
 		if code != qerrors.CodeConnectionRefused && code != qerrors.CodeCoreNotRunning {
 			report.CoreRunning = true
 		}
+		logger.Error("doctor core check failed",
+			"component", "cli",
+			"operation", "doctor",
+			"check", "core_status",
+			"error_code", code,
+		)
 
 		logger.Info("doctor report generated",
 			"component", "cli",
@@ -58,4 +124,27 @@ func Run(ctx context.Context, client *httpclient.Client, logger *logging.Logger)
 
 		return report, err
 	}
+}
+
+func extractProxyEnabled(payload map[string]any) bool {
+	rawItems, ok := payload["items"]
+	if !ok {
+		return false
+	}
+
+	items, ok := rawItems.([]any)
+	if !ok || len(items) == 0 {
+		return false
+	}
+
+	first, ok := items[0].(map[string]any)
+	if !ok {
+		return false
+	}
+
+	enabled, ok := first["enabled"].(bool)
+	if !ok {
+		return false
+	}
+	return enabled
 }

--- a/internal/cli/doctor/doctor_test.go
+++ b/internal/cli/doctor/doctor_test.go
@@ -73,3 +73,43 @@ func TestRunMarksConnectionFailureAsNotRunning(t *testing.T) {
 		t.Fatal("expected doctor to mark unreachable core as not running")
 	}
 }
+
+func TestRunFetchesProxyStatusWhenCoreIsReachable(t *testing.T) {
+	t.Parallel()
+
+	logger, err := logging.New(logging.Config{Level: "debug"})
+	if err != nil {
+		t.Fatalf("logger init failed: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/status":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		case "/api/v1/proxy/status":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"items":[{"enabled":true}]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":"UNKNOWN_ERROR","message":"not found"}`))
+		}
+	}))
+	defer server.Close()
+
+	client := httpclient.New(server.URL, "", logger)
+	report, err := Run(context.Background(), client, logger)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !report.CoreRunning {
+		t.Fatal("expected core_running=true")
+	}
+	if !report.ProxyStatusReachable {
+		t.Fatal("expected proxy_status_reachable=true")
+	}
+	if !report.ProxyEnabled {
+		t.Fatal("expected proxy_enabled=true")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,17 @@ type ProvidersConfig struct {
 	Copilot   ProviderEntry `json:"copilot"`
 }
 
+type ProxyAnthropicConfig struct {
+	BaseURL        string `json:"base_url"`
+	Version        string `json:"version"`
+	TimeoutSeconds int    `json:"timeout_seconds"`
+}
+
+type ProxyConfig struct {
+	Enabled   bool                 `json:"enabled"`
+	Anthropic ProxyAnthropicConfig `json:"anthropic"`
+}
+
 type StorageConfig struct {
 	Path string `json:"path"`
 }
@@ -49,6 +60,7 @@ type LoggingConfig struct {
 type Config struct {
 	Core      CoreConfig      `json:"core"`
 	Providers ProvidersConfig `json:"providers"`
+	Proxy     ProxyConfig     `json:"proxy"`
 	Storage   StorageConfig   `json:"storage"`
 	Logging   LoggingConfig   `json:"logging"`
 }
@@ -79,6 +91,14 @@ func Default() Config {
 			Port:      8765,
 		},
 		Providers: ProvidersConfig{},
+		Proxy: ProxyConfig{
+			Enabled: false,
+			Anthropic: ProxyAnthropicConfig{
+				BaseURL:        "https://api.anthropic.com",
+				Version:        "2023-06-01",
+				TimeoutSeconds: 30,
+			},
+		},
 		Storage: StorageConfig{
 			Path: "",
 		},
@@ -122,12 +142,9 @@ func Load(opts LoadOptions, logger *logging.Logger) (Config, Metadata, error) {
 
 	switch {
 	case fileExists(primaryPath):
-		targetPath = primaryPath
 	case fileExists(legacyPath):
 		targetPath = legacyPath
 		usedLegacy = true
-	default:
-		targetPath = primaryPath
 	}
 
 	meta := Metadata{
@@ -248,6 +265,17 @@ func mergeConfig(base Config, loaded Config) Config {
 	base.Core.AutoStart = loaded.Core.AutoStart || base.Core.AutoStart
 
 	base.Providers = loaded.Providers
+	base.Proxy.Enabled = loaded.Proxy.Enabled
+
+	if strings.TrimSpace(loaded.Proxy.Anthropic.BaseURL) != "" {
+		base.Proxy.Anthropic.BaseURL = loaded.Proxy.Anthropic.BaseURL
+	}
+	if strings.TrimSpace(loaded.Proxy.Anthropic.Version) != "" {
+		base.Proxy.Anthropic.Version = loaded.Proxy.Anthropic.Version
+	}
+	if loaded.Proxy.Anthropic.TimeoutSeconds > 0 {
+		base.Proxy.Anthropic.TimeoutSeconds = loaded.Proxy.Anthropic.TimeoutSeconds
+	}
 
 	if strings.TrimSpace(loaded.Storage.Path) != "" {
 		base.Storage.Path = loaded.Storage.Path
@@ -275,6 +303,10 @@ func applyEnv(cfg Config, logger *logging.Logger) Config {
 	overrideString(&cfg.Providers.OpenAI.Key, "OPENAI_API_KEY", logger)
 	overrideString(&cfg.Providers.Anthropic.Key, "ANTHROPIC_API_KEY", logger)
 	overrideString(&cfg.Providers.Copilot.Token, "GITHUB_TOKEN", logger)
+	overrideBool(&cfg.Proxy.Enabled, "QUIVERKEEP_PROXY_ENABLED", logger)
+	overrideString(&cfg.Proxy.Anthropic.BaseURL, "QUIVERKEEP_PROXY_ANTHROPIC_BASE_URL", logger)
+	overrideString(&cfg.Proxy.Anthropic.Version, "QUIVERKEEP_PROXY_ANTHROPIC_VERSION", logger)
+	overrideInt(&cfg.Proxy.Anthropic.TimeoutSeconds, "QUIVERKEEP_PROXY_TIMEOUT_SECONDS", logger)
 
 	return cfg
 }
@@ -364,6 +396,26 @@ func overrideInt(target *int, key string, logger *logging.Logger) {
 		}
 		return
 	}
+	*target = parsed
+	if logger != nil {
+		logger.Debug("config override from env", "field", strings.ToLower(key), "value", parsed)
+	}
+}
+
+func overrideBool(target *bool, key string, logger *logging.Logger) {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return
+	}
+
+	parsed, err := strconv.ParseBool(raw)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("invalid bool env value ignored", "field", strings.ToLower(key), "value", raw)
+		}
+		return
+	}
+
 	*target = parsed
 	if logger != nil {
 		logger.Debug("config override from env", "field", strings.ToLower(key), "value", parsed)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -95,6 +95,51 @@ func TestSanitizedMasksSecrets(t *testing.T) {
 	}
 }
 
+func TestProxyEnvOverrides(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.json")
+	logger := newTestLogger(t)
+
+	if err := os.Setenv("QUIVERKEEP_PROXY_ENABLED", "true"); err != nil {
+		t.Fatalf("setenv failed: %v", err)
+	}
+	if err := os.Setenv("QUIVERKEEP_PROXY_ANTHROPIC_BASE_URL", "https://proxy.example.test"); err != nil {
+		t.Fatalf("setenv failed: %v", err)
+	}
+	if err := os.Setenv("QUIVERKEEP_PROXY_ANTHROPIC_VERSION", "2024-01-01"); err != nil {
+		t.Fatalf("setenv failed: %v", err)
+	}
+	if err := os.Setenv("QUIVERKEEP_PROXY_TIMEOUT_SECONDS", "42"); err != nil {
+		t.Fatalf("setenv failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Unsetenv("QUIVERKEEP_PROXY_ENABLED")
+		_ = os.Unsetenv("QUIVERKEEP_PROXY_ANTHROPIC_BASE_URL")
+		_ = os.Unsetenv("QUIVERKEEP_PROXY_ANTHROPIC_VERSION")
+		_ = os.Unsetenv("QUIVERKEEP_PROXY_TIMEOUT_SECONDS")
+	})
+
+	cfg, _, err := Load(LoadOptions{ConfigPath: configPath}, logger)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !cfg.Proxy.Enabled {
+		t.Fatalf("expected proxy to be enabled by env")
+	}
+	if cfg.Proxy.Anthropic.BaseURL != "https://proxy.example.test" {
+		t.Fatalf("unexpected anthropic base url: %s", cfg.Proxy.Anthropic.BaseURL)
+	}
+	if cfg.Proxy.Anthropic.Version != "2024-01-01" {
+		t.Fatalf("unexpected anthropic version: %s", cfg.Proxy.Anthropic.Version)
+	}
+	if cfg.Proxy.Anthropic.TimeoutSeconds != 42 {
+		t.Fatalf("unexpected anthropic timeout: %d", cfg.Proxy.Anthropic.TimeoutSeconds)
+	}
+}
+
 func newTestLogger(t *testing.T) *logging.Logger {
 	t.Helper()
 	logger, err := logging.New(logging.Config{Level: "debug"})

--- a/internal/errors/codes.go
+++ b/internal/errors/codes.go
@@ -21,6 +21,10 @@ const (
 	CodeStorageCorrupt      Code = "STORAGE_CORRUPT_ERROR"
 	CodeValidationFailed    Code = "VALIDATION_FAILED"
 	CodeInternalServerError Code = "INTERNAL_SERVER_ERROR"
+	CodeProxyDisabled       Code = "PROXY_DISABLED"
+	CodeProxyNotConfigured  Code = "PROXY_NOT_CONFIGURED"
+	CodeProxyUpstreamError  Code = "PROXY_UPSTREAM_ERROR"
+	CodeProxyTimeout        Code = "PROXY_TIMEOUT"
 )
 
 type AppError struct {

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -14,13 +14,15 @@ type Config struct {
 }
 
 type Logger struct {
-	base *slog.Logger
+	base    *slog.Logger
+	closers []io.Closer
 }
 
 func New(cfg Config) (*Logger, error) {
 	level := parseLevel(cfg.Level)
 
 	var writer io.Writer = os.Stdout
+	closers := make([]io.Closer, 0, 1)
 	if cfg.Path != "" {
 		if err := os.MkdirAll(filepath.Dir(cfg.Path), 0o700); err != nil {
 			return nil, err
@@ -31,14 +33,15 @@ func New(cfg Config) (*Logger, error) {
 			return nil, err
 		}
 		writer = io.MultiWriter(os.Stdout, file)
+		closers = append(closers, file)
 	}
 
 	handler := slog.NewJSONHandler(writer, &slog.HandlerOptions{Level: level})
-	return &Logger{base: slog.New(handler)}, nil
+	return &Logger{base: slog.New(handler), closers: closers}, nil
 }
 
 func (l *Logger) With(kv ...any) *Logger {
-	return &Logger{base: l.base.With(kv...)}
+	return &Logger{base: l.base.With(kv...), closers: l.closers}
 }
 
 func (l *Logger) Debug(msg string, kv ...any) {
@@ -55,6 +58,17 @@ func (l *Logger) Warn(msg string, kv ...any) {
 
 func (l *Logger) Error(msg string, kv ...any) {
 	l.base.Error(msg, kv...)
+}
+
+func (l *Logger) Close() error {
+	var firstErr error
+	for _, closer := range l.closers {
+		if err := closer.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	l.closers = nil
+	return firstErr
 }
 
 func parseLevel(raw string) slog.Level {

--- a/internal/proxy/api/anthropic_proxy.go
+++ b/internal/proxy/api/anthropic_proxy.go
@@ -1,0 +1,482 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ichinya/quiverkeep-core/internal/config"
+	"github.com/ichinya/quiverkeep-core/internal/domain"
+	qerrors "github.com/ichinya/quiverkeep-core/internal/errors"
+	"github.com/ichinya/quiverkeep-core/internal/logging"
+)
+
+const (
+	anthropicMessagesPath   = "/v1/messages"
+	defaultAnthropicBaseURL = "https://api.anthropic.com"
+	defaultAnthropicVersion = "2023-06-01"
+)
+
+type UsageWriter interface {
+	InsertUsage(ctx context.Context, usage domain.UsageRecord) error
+}
+
+type ForwardRequest struct {
+	Payload       []byte
+	AnthropicBeta string
+	RequestID     string
+}
+
+type ForwardResponse struct {
+	StatusCode int
+	Body       []byte
+	Headers    http.Header
+}
+
+type Status struct {
+	Provider         string     `json:"provider"`
+	Enabled          bool       `json:"enabled"`
+	Configured       bool       `json:"configured"`
+	LastAttemptAt    *time.Time `json:"last_attempt_at,omitempty"`
+	LastSuccessAt    *time.Time `json:"last_success_at,omitempty"`
+	LastErrorCode    string     `json:"last_error_code,omitempty"`
+	LastErrorMessage string     `json:"last_error_message,omitempty"`
+	LastUpstreamCode *int       `json:"last_upstream_code,omitempty"`
+}
+
+type AnthropicProxy struct {
+	cfg    config.Config
+	logger *logging.Logger
+	store  UsageWriter
+	client *http.Client
+
+	mu     sync.RWMutex
+	status Status
+}
+
+func NewAnthropicProxy(cfg config.Config, logger *logging.Logger, store UsageWriter) *AnthropicProxy {
+	timeoutSeconds := cfg.Proxy.Anthropic.TimeoutSeconds
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = 30
+	}
+
+	return &AnthropicProxy{
+		cfg:    cfg,
+		logger: logger,
+		store:  store,
+		client: &http.Client{Timeout: time.Duration(timeoutSeconds) * time.Second},
+		status: Status{
+			Provider:   "anthropic",
+			Enabled:    cfg.Proxy.Enabled,
+			Configured: strings.TrimSpace(cfg.Providers.Anthropic.Key) != "",
+		},
+	}
+}
+
+func (p *AnthropicProxy) Forward(ctx context.Context, req ForwardRequest) (ForwardResponse, error) {
+	modelHint := modelHintFromPayload(req.Payload)
+	p.markAttempt(req.RequestID, modelHint)
+
+	if !p.cfg.Proxy.Enabled {
+		err := qerrors.New(qerrors.CodeProxyDisabled, "proxy mode is disabled")
+		p.markFailure(req.RequestID, err, nil)
+		return ForwardResponse{}, err
+	}
+
+	apiKey := strings.TrimSpace(p.cfg.Providers.Anthropic.Key)
+	if apiKey == "" {
+		err := qerrors.New(qerrors.CodeProxyNotConfigured, "anthropic provider key is not configured")
+		p.markFailure(req.RequestID, err, nil)
+		return ForwardResponse{}, err
+	}
+
+	baseURL := strings.TrimSpace(p.cfg.Proxy.Anthropic.BaseURL)
+	if baseURL == "" {
+		baseURL = defaultAnthropicBaseURL
+	}
+	endpoint := strings.TrimRight(baseURL, "/") + anthropicMessagesPath
+	logEndpoint, redacted := sanitizeEndpointForLogs(endpoint)
+	p.logger.Debug("proxy endpoint resolved",
+		"component", "proxy",
+		"operation", "proxy_forward",
+		"provider", "anthropic",
+		"request_id", req.RequestID,
+		"endpoint", logEndpoint,
+		"endpoint_redacted", redacted,
+	)
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(req.Payload))
+	if err != nil {
+		proxyErr := qerrors.New(qerrors.CodeProxyUpstreamError, "failed to create upstream request")
+		p.markFailure(req.RequestID, proxyErr, nil)
+		p.logger.Error("proxy upstream request creation failed",
+			"component", "proxy",
+			"operation", "proxy_forward",
+			"provider", "anthropic",
+			"request_id", req.RequestID,
+			"error_code", qerrors.CodeOf(proxyErr),
+			"retry_decision", "no_retry",
+		)
+		return ForwardResponse{}, proxyErr
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("X-API-Key", apiKey)
+	version := strings.TrimSpace(p.cfg.Proxy.Anthropic.Version)
+	if version == "" {
+		version = defaultAnthropicVersion
+	}
+	httpReq.Header.Set("Anthropic-Version", version)
+	if beta := strings.TrimSpace(req.AnthropicBeta); beta != "" {
+		httpReq.Header.Set("Anthropic-Beta", beta)
+	}
+
+	p.logger.Debug("proxy forward start",
+		"component", "proxy",
+		"operation", "proxy_forward",
+		"provider", "anthropic",
+		"request_id", req.RequestID,
+		"model_hint", modelHint,
+	)
+
+	started := time.Now()
+	p.logger.Info("proxy upstream call start",
+		"component", "proxy",
+		"operation", "proxy_forward",
+		"provider", "anthropic",
+		"request_id", req.RequestID,
+		"endpoint", logEndpoint,
+	)
+
+	upstreamResp, err := p.client.Do(httpReq)
+	if err != nil {
+		duration := time.Since(started).Milliseconds()
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			timeoutErr := qerrors.New(qerrors.CodeProxyTimeout, "anthropic upstream request timed out")
+			p.markFailure(req.RequestID, timeoutErr, nil)
+			p.logger.Error("proxy upstream call failed",
+				"component", "proxy",
+				"operation", "proxy_forward",
+				"provider", "anthropic",
+				"request_id", req.RequestID,
+				"error_code", qerrors.CodeOf(timeoutErr),
+				"error_class", classifyForwardError(err),
+				"duration_ms", duration,
+				"retry_decision", "no_retry",
+			)
+			return ForwardResponse{}, timeoutErr
+		}
+		proxyErr := qerrors.New(qerrors.CodeProxyUpstreamError, "anthropic upstream request failed")
+		p.markFailure(req.RequestID, proxyErr, nil)
+		p.logger.Error("proxy upstream call failed",
+			"component", "proxy",
+			"operation", "proxy_forward",
+			"provider", "anthropic",
+			"request_id", req.RequestID,
+			"error_code", qerrors.CodeOf(proxyErr),
+			"error_class", classifyForwardError(err),
+			"duration_ms", duration,
+			"retry_decision", "no_retry",
+		)
+		return ForwardResponse{}, proxyErr
+	}
+	defer upstreamResp.Body.Close()
+
+	body, err := io.ReadAll(upstreamResp.Body)
+	if err != nil {
+		proxyErr := qerrors.New(qerrors.CodeProxyUpstreamError, "failed reading anthropic upstream response")
+		p.markFailure(req.RequestID, proxyErr, &upstreamResp.StatusCode)
+		p.logger.Error("proxy upstream response read failed",
+			"component", "proxy",
+			"operation", "proxy_forward",
+			"provider", "anthropic",
+			"request_id", req.RequestID,
+			"error_code", qerrors.CodeOf(proxyErr),
+			"status", upstreamResp.StatusCode,
+			"error_class", classifyForwardError(err),
+			"retry_decision", "no_retry",
+		)
+		return ForwardResponse{}, proxyErr
+	}
+
+	duration := time.Since(started).Milliseconds()
+	p.logger.Info("proxy upstream call finish",
+		"component", "proxy",
+		"operation", "proxy_forward",
+		"provider", "anthropic",
+		"request_id", req.RequestID,
+		"status", upstreamResp.StatusCode,
+		"duration_ms", duration,
+	)
+
+	if upstreamResp.StatusCode < http.StatusOK || upstreamResp.StatusCode >= http.StatusMultipleChoices {
+		proxyErr := qerrors.New(qerrors.CodeProxyUpstreamError, fmt.Sprintf("anthropic upstream returned %d", upstreamResp.StatusCode))
+		p.markFailure(req.RequestID, proxyErr, &upstreamResp.StatusCode)
+		p.logger.Error("proxy upstream returned non-success status",
+			"component", "proxy",
+			"operation", "proxy_forward",
+			"provider", "anthropic",
+			"request_id", req.RequestID,
+			"status", upstreamResp.StatusCode,
+			"duration_ms", duration,
+			"error_code", qerrors.CodeOf(proxyErr),
+			"retry_decision", "no_retry",
+		)
+		return ForwardResponse{}, proxyErr
+	}
+
+	p.markSuccess(req.RequestID, upstreamResp.StatusCode)
+	p.trackUsage(ctx, body, upstreamResp.StatusCode, req.RequestID)
+
+	return ForwardResponse{
+		StatusCode: upstreamResp.StatusCode,
+		Body:       body,
+		Headers:    copyProxyHeaders(upstreamResp.Header),
+	}, nil
+}
+
+func (p *AnthropicProxy) Status() Status {
+	p.mu.RLock()
+	status := p.status
+	p.mu.RUnlock()
+
+	status.Enabled = p.cfg.Proxy.Enabled
+	status.Configured = strings.TrimSpace(p.cfg.Providers.Anthropic.Key) != ""
+	if status.LastAttemptAt == nil && (status.LastSuccessAt != nil || status.LastErrorCode != "") {
+		p.logger.Warn("proxy diagnostics state is inconsistent",
+			"component", "proxy",
+			"operation", "proxy_status",
+			"provider", "anthropic",
+		)
+	}
+	p.logger.Debug("proxy diagnostics read",
+		"component", "proxy",
+		"operation", "proxy_status",
+		"provider", "anthropic",
+		"enabled", status.Enabled,
+		"configured", status.Configured,
+		"last_error_code", status.LastErrorCode,
+		"last_upstream_code", status.LastUpstreamCode,
+	)
+	return status
+}
+
+func (p *AnthropicProxy) trackUsage(ctx context.Context, body []byte, statusCode int, requestID string) {
+	if p.store == nil {
+		return
+	}
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		return
+	}
+
+	var response struct {
+		Model string `json:"model"`
+		Usage struct {
+			InputTokens  int64 `json:"input_tokens"`
+			OutputTokens int64 `json:"output_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		p.logger.Warn("proxy usage parse failed",
+			"component", "proxy",
+			"operation", "proxy_usage",
+			"provider", "anthropic",
+			"request_id", requestID,
+			"error_class", classifyForwardError(err),
+		)
+		return
+	}
+
+	if response.Usage.InputTokens == 0 && response.Usage.OutputTokens == 0 {
+		p.logger.Warn("proxy usage missing token fields",
+			"component", "proxy",
+			"operation", "proxy_usage",
+			"provider", "anthropic",
+			"request_id", requestID,
+			"error_class", "missing_usage",
+		)
+		return
+	}
+
+	model := strings.TrimSpace(response.Model)
+	if model == "" {
+		model = "unknown"
+	}
+
+	p.logger.Debug("proxy usage extracted",
+		"component", "proxy",
+		"operation", "proxy_usage",
+		"provider", "anthropic",
+		"request_id", requestID,
+		"tokens_in", response.Usage.InputTokens,
+		"tokens_out", response.Usage.OutputTokens,
+		"cost", 0,
+		"model", model,
+	)
+
+	err := p.store.InsertUsage(ctx, domain.UsageRecord{
+		Service:   "anthropic",
+		Model:     model,
+		TokensIn:  response.Usage.InputTokens,
+		TokensOut: response.Usage.OutputTokens,
+		Cost:      0,
+		CreatedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		p.logger.Warn("proxy usage persist failed",
+			"component", "proxy",
+			"operation", "proxy_usage",
+			"provider", "anthropic",
+			"request_id", requestID,
+			"error_class", classifyForwardError(err),
+		)
+		return
+	}
+
+	p.logger.Info("proxy usage persisted",
+		"component", "proxy",
+		"operation", "proxy_usage",
+		"provider", "anthropic",
+		"request_id", requestID,
+		"tokens_in", response.Usage.InputTokens,
+		"tokens_out", response.Usage.OutputTokens,
+		"model", model,
+	)
+}
+
+func (p *AnthropicProxy) markAttempt(requestID string, modelHint string) {
+	now := time.Now().UTC()
+	p.mu.Lock()
+	p.status.LastAttemptAt = &now
+	p.mu.Unlock()
+
+	p.logger.Info("proxy diagnostics state transition",
+		"component", "proxy",
+		"operation", "proxy_status",
+		"provider", "anthropic",
+		"request_id", requestID,
+		"state", "attempt",
+		"model_hint", modelHint,
+	)
+}
+
+func (p *AnthropicProxy) markSuccess(requestID string, statusCode int) {
+	now := time.Now().UTC()
+	p.mu.Lock()
+	p.status.LastSuccessAt = &now
+	p.status.LastErrorCode = ""
+	p.status.LastErrorMessage = ""
+	p.status.LastUpstreamCode = &statusCode
+	p.mu.Unlock()
+
+	p.logger.Info("proxy diagnostics state transition",
+		"component", "proxy",
+		"operation", "proxy_status",
+		"provider", "anthropic",
+		"request_id", requestID,
+		"state", "success",
+		"last_upstream_code", statusCode,
+	)
+}
+
+func (p *AnthropicProxy) markFailure(requestID string, err error, statusCode *int) {
+	p.mu.Lock()
+	p.status.LastErrorCode = string(qerrors.CodeOf(err))
+	p.status.LastErrorMessage = statusMessageFromError(err)
+	p.status.LastUpstreamCode = statusCode
+	p.mu.Unlock()
+
+	p.logger.Info("proxy diagnostics state transition",
+		"component", "proxy",
+		"operation", "proxy_status",
+		"provider", "anthropic",
+		"request_id", requestID,
+		"state", "failure",
+		"error_code", qerrors.CodeOf(err),
+		"last_upstream_code", statusCode,
+	)
+}
+
+func copyProxyHeaders(src http.Header) http.Header {
+	dst := make(http.Header)
+	for _, key := range []string{"Content-Type", "Anthropic-Request-Id", "X-Request-Id"} {
+		values := src.Values(key)
+		if len(values) == 0 {
+			continue
+		}
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
+	return dst
+}
+
+func modelHintFromPayload(payload []byte) string {
+	if len(payload) == 0 {
+		return ""
+	}
+
+	var request struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(payload, &request); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(request.Model)
+}
+
+func sanitizeEndpointForLogs(rawEndpoint string) (string, bool) {
+	parsed, err := url.Parse(rawEndpoint)
+	if err != nil {
+		return rawEndpoint, false
+	}
+
+	redacted := false
+	if parsed.User != nil {
+		parsed.User = url.User("redacted")
+		redacted = true
+	}
+	if parsed.RawQuery != "" {
+		parsed.RawQuery = ""
+		redacted = true
+	}
+	if parsed.Fragment != "" {
+		parsed.Fragment = ""
+		redacted = true
+	}
+
+	return parsed.String(), redacted
+}
+
+func classifyForwardError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return "timeout"
+	}
+	return "upstream_error"
+}
+
+func statusMessageFromError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	var appErr *qerrors.AppError
+	if errors.As(err, &appErr) {
+		return appErr.Message
+	}
+	return "proxy operation failed"
+}

--- a/internal/proxy/api/anthropic_proxy_test.go
+++ b/internal/proxy/api/anthropic_proxy_test.go
@@ -1,0 +1,292 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ichinya/quiverkeep-core/internal/config"
+	"github.com/ichinya/quiverkeep-core/internal/domain"
+	qerrors "github.com/ichinya/quiverkeep-core/internal/errors"
+	"github.com/ichinya/quiverkeep-core/internal/logging"
+)
+
+func TestAnthropicProxyForwardSuccessTracksUsage(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if r.Header.Get("X-API-Key") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Anthropic-Request-Id", "anthropic_req_1")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1","model":"claude-3-5-sonnet","usage":{"input_tokens":12,"output_tokens":7}}`))
+	}))
+	defer upstream.Close()
+
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "proxy.log")
+	logger, err := logging.New(logging.Config{Level: "debug", Path: logPath})
+	if err != nil {
+		t.Fatalf("logger init failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logger.Close()
+	})
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = true
+	cfg.Proxy.Anthropic.BaseURL = upstream.URL
+	cfg.Proxy.Anthropic.TimeoutSeconds = 2
+	cfg.Providers.Anthropic.Key = "anthropic-test-key"
+
+	store := &captureStore{}
+	proxy := NewAnthropicProxy(cfg, logger, store)
+
+	response, err := proxy.Forward(context.Background(), ForwardRequest{
+		Payload:   []byte(`{"model":"claude-3-5-sonnet","messages":[]}`),
+		RequestID: "req-success",
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", response.StatusCode)
+	}
+	if response.Headers.Get("Anthropic-Request-Id") != "anthropic_req_1" {
+		t.Fatalf("expected anthropic request header passthrough")
+	}
+
+	records := store.recordsSnapshot()
+	if len(records) != 1 {
+		t.Fatalf("expected one usage record, got %d", len(records))
+	}
+	if records[0].TokensIn != 12 || records[0].TokensOut != 7 {
+		t.Fatalf("unexpected usage record: %+v", records[0])
+	}
+
+	status := proxy.Status()
+	if status.LastSuccessAt == nil {
+		t.Fatalf("expected success timestamp in diagnostics")
+	}
+	if status.LastErrorCode != "" {
+		t.Fatalf("expected empty error code after success, got %s", status.LastErrorCode)
+	}
+
+	logPayload, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed reading proxy log: %v", err)
+	}
+	logText := string(logPayload)
+	if !strings.Contains(logText, `"operation":"proxy_usage"`) {
+		t.Fatalf("expected proxy usage operation logs")
+	}
+	if !strings.Contains(logText, `"tokens_in":12`) {
+		t.Fatalf("expected extracted usage tokens in logs")
+	}
+}
+
+func TestAnthropicProxyForwardDisabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = false
+	cfg.Providers.Anthropic.Key = "anthropic-test-key"
+
+	logger, err := logging.New(logging.Config{Level: "debug"})
+	if err != nil {
+		t.Fatalf("logger init failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logger.Close()
+	})
+
+	proxy := NewAnthropicProxy(cfg, logger, &captureStore{})
+	_, err = proxy.Forward(context.Background(), ForwardRequest{
+		Payload:   []byte(`{"model":"claude-3-5-sonnet","messages":[]}`),
+		RequestID: "req-disabled",
+	})
+	if qerrors.CodeOf(err) != qerrors.CodeProxyDisabled {
+		t.Fatalf("expected PROXY_DISABLED, got %v", qerrors.CodeOf(err))
+	}
+
+	status := proxy.Status()
+	if status.LastErrorCode != string(qerrors.CodeProxyDisabled) {
+		t.Fatalf("expected diagnostics error code PROXY_DISABLED, got %s", status.LastErrorCode)
+	}
+}
+
+func TestAnthropicProxyForwardNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = true
+	cfg.Providers.Anthropic.Key = ""
+
+	logger, err := logging.New(logging.Config{Level: "debug"})
+	if err != nil {
+		t.Fatalf("logger init failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logger.Close()
+	})
+
+	proxy := NewAnthropicProxy(cfg, logger, &captureStore{})
+	_, err = proxy.Forward(context.Background(), ForwardRequest{
+		Payload:   []byte(`{"model":"claude-3-5-sonnet","messages":[]}`),
+		RequestID: "req-not-configured",
+	})
+	if qerrors.CodeOf(err) != qerrors.CodeProxyNotConfigured {
+		t.Fatalf("expected PROXY_NOT_CONFIGURED, got %v", qerrors.CodeOf(err))
+	}
+}
+
+func TestAnthropicProxyMapsUpstreamNonSuccess(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"upstream_error"}}`))
+	}))
+	defer upstream.Close()
+
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "proxy.log")
+	logger, err := logging.New(logging.Config{Level: "debug", Path: logPath})
+	if err != nil {
+		t.Fatalf("logger init failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logger.Close()
+	})
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = true
+	cfg.Proxy.Anthropic.BaseURL = upstream.URL
+	cfg.Providers.Anthropic.Key = "anthropic-test-key"
+
+	proxy := NewAnthropicProxy(cfg, logger, &captureStore{})
+	_, err = proxy.Forward(context.Background(), ForwardRequest{
+		Payload:   []byte(`{"model":"claude-3-5-sonnet","messages":[]}`),
+		RequestID: "req-upstream-failure",
+	})
+	if qerrors.CodeOf(err) != qerrors.CodeProxyUpstreamError {
+		t.Fatalf("expected PROXY_UPSTREAM_ERROR, got %v", qerrors.CodeOf(err))
+	}
+
+	status := proxy.Status()
+	if status.LastUpstreamCode == nil || *status.LastUpstreamCode != http.StatusBadGateway {
+		t.Fatalf("expected last upstream status 502 in diagnostics")
+	}
+	if status.LastErrorCode != string(qerrors.CodeProxyUpstreamError) {
+		t.Fatalf("expected diagnostics error code PROXY_UPSTREAM_ERROR, got %s", status.LastErrorCode)
+	}
+
+	logPayload, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed reading proxy log: %v", err)
+	}
+	logText := string(logPayload)
+	if !strings.Contains(logText, `"error_code":"PROXY_UPSTREAM_ERROR"`) {
+		t.Fatalf("expected stable upstream error code in logs")
+	}
+	if !strings.Contains(logText, `"retry_decision":"no_retry"`) {
+		t.Fatalf("expected retry decision field in logs")
+	}
+}
+
+func TestAnthropicProxyMapsTimeout(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(1200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1"}`))
+	}))
+	defer upstream.Close()
+
+	logger, err := logging.New(logging.Config{Level: "debug"})
+	if err != nil {
+		t.Fatalf("logger init failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logger.Close()
+	})
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = true
+	cfg.Proxy.Anthropic.BaseURL = upstream.URL
+	cfg.Proxy.Anthropic.TimeoutSeconds = 1
+	cfg.Providers.Anthropic.Key = "anthropic-test-key"
+
+	proxy := NewAnthropicProxy(cfg, logger, &captureStore{})
+	_, err = proxy.Forward(context.Background(), ForwardRequest{
+		Payload:   []byte(`{"model":"claude-3-5-sonnet","messages":[]}`),
+		RequestID: "req-timeout",
+	})
+	if qerrors.CodeOf(err) != qerrors.CodeProxyTimeout {
+		t.Fatalf("expected PROXY_TIMEOUT, got %v", qerrors.CodeOf(err))
+	}
+}
+
+func TestSanitizeEndpointForLogsRedactsCredentialsAndQuery(t *testing.T) {
+	t.Parallel()
+
+	sanitized, redacted := sanitizeEndpointForLogs("https://user:secret@example.test/v1/messages?token=secret#frag")
+	if !redacted {
+		t.Fatalf("expected endpoint to be redacted")
+	}
+	if strings.Contains(sanitized, "secret") {
+		t.Fatalf("sanitized endpoint leaked secret")
+	}
+	if strings.Contains(sanitized, "?") {
+		t.Fatalf("sanitized endpoint leaked query")
+	}
+	if strings.Contains(sanitized, "#") {
+		t.Fatalf("sanitized endpoint leaked fragment")
+	}
+}
+
+type captureStore struct {
+	mu      sync.Mutex
+	records []domain.UsageRecord
+	fail    bool
+}
+
+func (s *captureStore) InsertUsage(_ context.Context, usage domain.UsageRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.fail {
+		return errors.New("insert usage failed")
+	}
+
+	s.records = append(s.records, usage)
+	return nil
+}
+
+func (s *captureStore) recordsSnapshot() []domain.UsageRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	records := make([]domain.UsageRecord, len(s.records))
+	copy(records, s.records)
+	return records
+}

--- a/internal/storage/lock/lock_test.go
+++ b/internal/storage/lock/lock_test.go
@@ -56,7 +56,11 @@ func TestAcquireRemovesStaleLockWhenOwnerProcessIsGone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected stale lock to be replaced, got %v", err)
 	}
-	defer held.Release()
+	defer func() {
+		if releaseErr := held.Release(); releaseErr != nil {
+			t.Fatalf("release lock failed: %v", releaseErr)
+		}
+	}()
 
 	content, err := os.ReadFile(lockPath)
 	if err != nil {

--- a/internal/storage/lock/process_windows.go
+++ b/internal/storage/lock/process_windows.go
@@ -19,7 +19,9 @@ func processExists(pid int) bool {
 	if err != nil {
 		return errors.Is(err, windows.ERROR_ACCESS_DENIED)
 	}
-	defer windows.CloseHandle(handle)
+	defer func() {
+		_ = windows.CloseHandle(handle)
+	}()
 
 	var code uint32
 	if err := windows.GetExitCodeProcess(handle, &code); err != nil {

--- a/test/integration/proxy_flow_test.go
+++ b/test/integration/proxy_flow_test.go
@@ -1,0 +1,164 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ichinya/quiverkeep-core/internal/api/server"
+	"github.com/ichinya/quiverkeep-core/internal/cli/httpclient"
+	"github.com/ichinya/quiverkeep-core/internal/config"
+	"github.com/ichinya/quiverkeep-core/internal/domain"
+	"github.com/ichinya/quiverkeep-core/internal/logging"
+	"github.com/ichinya/quiverkeep-core/internal/storage"
+)
+
+func TestCoreProxyAnthropicFlow(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if r.Header.Get("X-API-Key") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"missing api key"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg_1","model":"claude-3-5-sonnet","usage":{"input_tokens":10,"output_tokens":5}}`))
+	}))
+	defer upstream.Close()
+
+	port := pickFreePort(t)
+	tempDir := t.TempDir()
+	cfg := config.Default()
+	cfg.Core.Port = port
+	cfg.Core.Bind = "127.0.0.1"
+	cfg.Core.URL = fmt.Sprintf("http://127.0.0.1:%d", port)
+	token := "core-token"
+	cfg.Core.Token = &token
+	cfg.Proxy.Enabled = true
+	cfg.Proxy.Anthropic.BaseURL = upstream.URL
+	cfg.Proxy.Anthropic.TimeoutSeconds = 2
+	cfg.Providers.Anthropic.Key = "anthropic-provider-key"
+	cfg.Storage.Path = filepath.Join(tempDir, "core.db")
+	meta := config.Metadata{
+		ConfigDir: tempDir,
+		Path:      filepath.Join(tempDir, "config.json"),
+	}
+
+	logger, err := logging.New(logging.Config{Level: "debug"})
+	if err != nil {
+		t.Fatalf("logger init failed: %v", err)
+	}
+
+	store, err := storage.New(cfg, meta, logger)
+	if err != nil {
+		t.Fatalf("store init failed: %v", err)
+	}
+	defer store.Close()
+
+	srv := server.New(cfg, logger, store)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- srv.Run(ctx)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+
+	if err := callProxyEndpoint(cfg.Core.URL, token); err != nil {
+		cancel()
+		<-done
+		t.Fatalf("proxy endpoint call failed: %v", err)
+	}
+
+	client := httpclient.New(cfg.Core.URL, token, logger)
+	var proxyStatus map[string]any
+	if err := client.GetJSON(context.Background(), "/api/v1/proxy/status", nil, &proxyStatus); err != nil {
+		cancel()
+		<-done
+		t.Fatalf("proxy status call failed: %v", err)
+	}
+
+	if !extractEnabledFlag(t, proxyStatus) {
+		cancel()
+		<-done
+		t.Fatalf("expected proxy enabled=true in status payload")
+	}
+
+	items, err := store.ListUsage(context.Background(), domain.UsageFilter{Service: "anthropic"})
+	if err != nil {
+		cancel()
+		<-done
+		t.Fatalf("usage query failed: %v", err)
+	}
+	if len(items) == 0 {
+		cancel()
+		<-done
+		t.Fatalf("expected persisted anthropic usage after proxy call")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("server run returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("server did not shutdown in time")
+	}
+}
+
+func callProxyEndpoint(baseURL string, token string) error {
+	body := strings.NewReader(`{"model":"claude-3-5-sonnet","messages":[]}`)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/api/v1/proxy/anthropic/messages", body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func extractEnabledFlag(t *testing.T, payload map[string]any) bool {
+	t.Helper()
+
+	rawItems, ok := payload["items"]
+	if !ok {
+		return false
+	}
+	items, ok := rawItems.([]any)
+	if !ok || len(items) == 0 {
+		return false
+	}
+	first, ok := items[0].(map[string]any)
+	if !ok {
+		return false
+	}
+	enabled, ok := first["enabled"].(bool)
+	return ok && enabled
+}

--- a/test/perf/proxy_perf_test.go
+++ b/test/perf/proxy_perf_test.go
@@ -1,0 +1,48 @@
+package perf
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ichinya/quiverkeep-core/internal/cli/httpclient"
+	"github.com/ichinya/quiverkeep-core/internal/logging"
+)
+
+func TestProxyStatusP99Under100ms(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/proxy/status" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"items":[{"provider":"anthropic","enabled":true,"configured":true}]}`))
+	}))
+	defer server.Close()
+
+	logger, err := logging.New(logging.Config{Level: "error"})
+	if err != nil {
+		t.Fatalf("logger init failed: %v", err)
+	}
+	client := httpclient.New(server.URL, "", logger)
+
+	samples := make([]time.Duration, 0, 100)
+	for i := 0; i < 100; i++ {
+		started := time.Now()
+		var payload map[string]any
+		if err := client.GetJSON(context.Background(), "/api/v1/proxy/status", nil, &payload); err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		samples = append(samples, time.Since(started))
+	}
+
+	p99 := percentile(samples, 0.99)
+	if p99 > 100*time.Millisecond {
+		t.Fatalf("expected p99 < 100ms, got %s", p99)
+	}
+}

--- a/test/security/security_test.go
+++ b/test/security/security_test.go
@@ -1,12 +1,17 @@
 package security
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/ichinya/quiverkeep-core/internal/api/handlers"
+	"github.com/ichinya/quiverkeep-core/internal/api/middleware"
 	"github.com/ichinya/quiverkeep-core/internal/config"
 	"github.com/ichinya/quiverkeep-core/internal/domain"
 	"github.com/ichinya/quiverkeep-core/internal/logging"
@@ -47,6 +52,9 @@ func TestFilePermissionsWhenSupported(t *testing.T) {
 	if err != nil {
 		t.Fatalf("logger init failed: %v", err)
 	}
+	t.Cleanup(func() {
+		_ = logger.Close()
+	})
 
 	cfg := config.Default()
 	cfg.Storage.Path = filepath.Join(tempDir, "secure.db")
@@ -93,5 +101,150 @@ func TestFilePermissionsWhenSupported(t *testing.T) {
 	}
 	if dbInfo.Mode().Perm() != 0o600 {
 		t.Fatalf("expected db permissions 0600, got %o", dbInfo.Mode().Perm())
+	}
+}
+
+func TestProxyEndpointRequiresTokenInRemoteMode(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	logger, err := logging.New(logging.Config{Level: "debug"})
+	if err != nil {
+		t.Fatalf("logger init failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logger.Close()
+	})
+
+	cfg := config.Default()
+	cfg.Core.Bind = "0.0.0.0"
+	cfg.Proxy.Enabled = true
+	cfg.Providers.Anthropic.Key = "anthropic-secret"
+	cfg.Storage.Path = filepath.Join(tempDir, "security.db")
+	meta := config.Metadata{
+		ConfigDir: tempDir,
+		Path:      filepath.Join(tempDir, "config.json"),
+	}
+
+	store, err := storage.New(cfg, meta, logger)
+	if err != nil {
+		t.Fatalf("store init failed: %v", err)
+	}
+	defer store.Close()
+
+	api := handlers.New(store, cfg, logger)
+	mux := http.NewServeMux()
+	api.Register(mux)
+	handler := middleware.Auth(cfg, logger, true)(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/proxy/anthropic/messages", strings.NewReader(`{"model":"claude"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for remote proxy request without token, got %d", rec.Code)
+	}
+}
+
+func TestProxyEndpointRequiresTokenInLoopbackMode(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "security.log")
+	logger, err := logging.New(logging.Config{Level: "debug", Path: logPath})
+	if err != nil {
+		t.Fatalf("logger init failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logger.Close()
+	})
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = true
+	cfg.Providers.Anthropic.Key = "anthropic-secret"
+	cfg.Storage.Path = filepath.Join(tempDir, "security.db")
+	meta := config.Metadata{
+		ConfigDir: tempDir,
+		Path:      filepath.Join(tempDir, "config.json"),
+	}
+
+	store, err := storage.New(cfg, meta, logger)
+	if err != nil {
+		t.Fatalf("store init failed: %v", err)
+	}
+	defer store.Close()
+
+	api := handlers.New(store, cfg, logger)
+	mux := http.NewServeMux()
+	api.Register(mux)
+	handler := middleware.Auth(cfg, logger, false)(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/proxy/anthropic/messages", strings.NewReader(`{"model":"claude"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for loopback proxy request without token, got %d", rec.Code)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed reading log file: %v", err)
+	}
+	logText := string(logBytes)
+	if !strings.Contains(logText, `"operation":"auth"`) {
+		t.Fatalf("expected auth operation log for proxy auth rejection")
+	}
+	if !strings.Contains(logText, `"reason":"proxy_spend"`) {
+		t.Fatalf("expected proxy_spend rejection reason in auth log")
+	}
+	if strings.Contains(logText, "anthropic-secret") {
+		t.Fatalf("auth logs leaked provider secret")
+	}
+}
+
+func TestProxyStatusDoesNotExposeProviderSecret(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	logger, err := logging.New(logging.Config{Level: "debug"})
+	if err != nil {
+		t.Fatalf("logger init failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logger.Close()
+	})
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = true
+	cfg.Providers.Anthropic.Key = "anthropic-secret-value"
+	cfg.Storage.Path = filepath.Join(tempDir, "security.db")
+	meta := config.Metadata{
+		ConfigDir: tempDir,
+		Path:      filepath.Join(tempDir, "config.json"),
+	}
+
+	store, err := storage.New(cfg, meta, logger)
+	if err != nil {
+		t.Fatalf("store init failed: %v", err)
+	}
+	defer store.Close()
+
+	api := handlers.New(store, cfg, logger)
+	mux := http.NewServeMux()
+	api.Register(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/proxy/status", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "anthropic-secret-value") {
+		t.Fatalf("proxy status leaked provider secret")
 	}
 }


### PR DESCRIPTION
## Summary

- implement `v0.2` API proxy slice for Anthropic with `/api/v1/proxy/anthropic/messages` and `/api/v1/proxy/status`
- add proxy config surface, OpenAPI contract updates, stable proxy error codes, and secure upstream forwarding
- enforce auth boundary for provider-spending proxy paths (including loopback token requirement for spend-capable endpoint)
- add usage/accounting extraction from proxied Anthropic responses with diagnostics state tracking
- extend CLI with `proxy status` and enrich `doctor` proxy diagnostics
- expand test coverage across unit, integration, perf, and security suites
- fix Go lint findings and make logger file handles closable for Windows-safe test cleanup

## Validation

- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`

## Issue linkage

Closes #2
Related to #8
Related to #3
