### PR TITLE
fix(proxy): cap upstream body and map provider 4xx

### DIFF
--- a/api/openapi/v1/openapi.yaml
+++ b/api/openapi/v1/openapi.yaml
@@ -65,7 +65,7 @@ paths:
         "200":
           description: Proxied Anthropic response payload
         "400":
-          description: Validation error (invalid method/content-type/body)
+          description: Validation error (invalid method/content-type/body or upstream client-side rejection)
           content:
             application/json:
               schema:

--- a/internal/api/handlers/handlers_test.go
+++ b/internal/api/handlers/handlers_test.go
@@ -227,6 +227,37 @@ func TestAnthropicProxyMapsUpstreamClientFailure(t *testing.T) {
 	}
 }
 
+func TestAnthropicProxyMapsUpstreamRateLimitFailure(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"rate_limit_error"}}`))
+	}))
+	defer upstream.Close()
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = true
+	cfg.Proxy.Anthropic.BaseURL = upstream.URL
+	cfg.Providers.Anthropic.Key = "test-anthropic"
+
+	api, cleanup := newTestAPIWithConfig(t, cfg)
+	defer cleanup()
+
+	mux := http.NewServeMux()
+	api.Register(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/proxy/anthropic/messages", strings.NewReader(`{"model":"claude-3-5-sonnet"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("expected status 502, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestAnthropicProxyMapsTimeoutFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/handlers_test.go
+++ b/internal/api/handlers/handlers_test.go
@@ -196,6 +196,37 @@ func TestAnthropicProxyMapsUpstreamFailure(t *testing.T) {
 	}
 }
 
+func TestAnthropicProxyMapsUpstreamClientFailure(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error"}}`))
+	}))
+	defer upstream.Close()
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = true
+	cfg.Proxy.Anthropic.BaseURL = upstream.URL
+	cfg.Providers.Anthropic.Key = "test-anthropic"
+
+	api, cleanup := newTestAPIWithConfig(t, cfg)
+	defer cleanup()
+
+	mux := http.NewServeMux()
+	api.Register(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/proxy/anthropic/messages", strings.NewReader(`{"model":"claude-3-5-sonnet"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
 func TestAnthropicProxyMapsTimeoutFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/proxy/api/anthropic_proxy.go
+++ b/internal/proxy/api/anthropic_proxy.go
@@ -500,8 +500,10 @@ func statusMessageFromError(err error) string {
 }
 
 func proxyErrorFromUpstreamStatus(statusCode int) *qerrors.AppError {
-	if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {
+	switch statusCode {
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
 		return qerrors.New(qerrors.CodeValidationFailed, fmt.Sprintf("anthropic request rejected with status %d", statusCode))
+	default:
+		return qerrors.New(qerrors.CodeProxyUpstreamError, fmt.Sprintf("anthropic upstream returned %d", statusCode))
 	}
-	return qerrors.New(qerrors.CodeProxyUpstreamError, fmt.Sprintf("anthropic upstream returned %d", statusCode))
 }

--- a/internal/proxy/api/anthropic_proxy.go
+++ b/internal/proxy/api/anthropic_proxy.go
@@ -24,6 +24,7 @@ const (
 	anthropicMessagesPath   = "/v1/messages"
 	defaultAnthropicBaseURL = "https://api.anthropic.com"
 	defaultAnthropicVersion = "2023-06-01"
+	maxUpstreamBodyBytes    = 8 * 1024 * 1024
 )
 
 type UsageWriter interface {
@@ -191,7 +192,8 @@ func (p *AnthropicProxy) Forward(ctx context.Context, req ForwardRequest) (Forwa
 	}
 	defer upstreamResp.Body.Close()
 
-	body, err := io.ReadAll(upstreamResp.Body)
+	limitedBody := io.LimitReader(upstreamResp.Body, maxUpstreamBodyBytes+1)
+	body, err := io.ReadAll(limitedBody)
 	if err != nil {
 		proxyErr := qerrors.New(qerrors.CodeProxyUpstreamError, "failed reading anthropic upstream response")
 		p.markFailure(req.RequestID, proxyErr, &upstreamResp.StatusCode)
@@ -203,6 +205,22 @@ func (p *AnthropicProxy) Forward(ctx context.Context, req ForwardRequest) (Forwa
 			"error_code", qerrors.CodeOf(proxyErr),
 			"status", upstreamResp.StatusCode,
 			"error_class", classifyForwardError(err),
+			"retry_decision", "no_retry",
+		)
+		return ForwardResponse{}, proxyErr
+	}
+	if len(body) > maxUpstreamBodyBytes {
+		proxyErr := qerrors.New(qerrors.CodeProxyUpstreamError, "anthropic upstream response exceeds size limit")
+		p.markFailure(req.RequestID, proxyErr, &upstreamResp.StatusCode)
+		p.logger.Error("proxy upstream response exceeded size limit",
+			"component", "proxy",
+			"operation", "proxy_forward",
+			"provider", "anthropic",
+			"request_id", req.RequestID,
+			"error_code", qerrors.CodeOf(proxyErr),
+			"status", upstreamResp.StatusCode,
+			"response_size", len(body),
+			"max_response_size", maxUpstreamBodyBytes,
 			"retry_decision", "no_retry",
 		)
 		return ForwardResponse{}, proxyErr
@@ -219,7 +237,7 @@ func (p *AnthropicProxy) Forward(ctx context.Context, req ForwardRequest) (Forwa
 	)
 
 	if upstreamResp.StatusCode < http.StatusOK || upstreamResp.StatusCode >= http.StatusMultipleChoices {
-		proxyErr := qerrors.New(qerrors.CodeProxyUpstreamError, fmt.Sprintf("anthropic upstream returned %d", upstreamResp.StatusCode))
+		proxyErr := proxyErrorFromUpstreamStatus(upstreamResp.StatusCode)
 		p.markFailure(req.RequestID, proxyErr, &upstreamResp.StatusCode)
 		p.logger.Error("proxy upstream returned non-success status",
 			"component", "proxy",
@@ -479,4 +497,11 @@ func statusMessageFromError(err error) string {
 		return appErr.Message
 	}
 	return "proxy operation failed"
+}
+
+func proxyErrorFromUpstreamStatus(statusCode int) *qerrors.AppError {
+	if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {
+		return qerrors.New(qerrors.CodeValidationFailed, fmt.Sprintf("anthropic request rejected with status %d", statusCode))
+	}
+	return qerrors.New(qerrors.CodeProxyUpstreamError, fmt.Sprintf("anthropic upstream returned %d", statusCode))
 }

--- a/internal/proxy/api/anthropic_proxy_test.go
+++ b/internal/proxy/api/anthropic_proxy_test.go
@@ -212,6 +212,84 @@ func TestAnthropicProxyMapsUpstreamNonSuccess(t *testing.T) {
 	}
 }
 
+func TestAnthropicProxyMapsUpstreamClientErrorToValidation(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"invalid_request_error"}}`))
+	}))
+	defer upstream.Close()
+
+	logger, err := logging.New(logging.Config{Level: "debug"})
+	if err != nil {
+		t.Fatalf("logger init failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logger.Close()
+	})
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = true
+	cfg.Proxy.Anthropic.BaseURL = upstream.URL
+	cfg.Providers.Anthropic.Key = "anthropic-test-key"
+
+	proxy := NewAnthropicProxy(cfg, logger, &captureStore{})
+	_, err = proxy.Forward(context.Background(), ForwardRequest{
+		Payload:   []byte(`{"model":"claude-3-5-sonnet","messages":[]}`),
+		RequestID: "req-upstream-400",
+	})
+	if qerrors.CodeOf(err) != qerrors.CodeValidationFailed {
+		t.Fatalf("expected VALIDATION_FAILED, got %v", qerrors.CodeOf(err))
+	}
+
+	status := proxy.Status()
+	if status.LastUpstreamCode == nil || *status.LastUpstreamCode != http.StatusBadRequest {
+		t.Fatalf("expected last upstream status 400 in diagnostics")
+	}
+	if status.LastErrorCode != string(qerrors.CodeValidationFailed) {
+		t.Fatalf("expected diagnostics error code VALIDATION_FAILED, got %s", status.LastErrorCode)
+	}
+}
+
+func TestAnthropicProxyFailsOnOversizedUpstreamBody(t *testing.T) {
+	t.Parallel()
+
+	oversizedContent := strings.Repeat("a", maxUpstreamBodyBytes+64)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"content":"` + oversizedContent + `"}`))
+	}))
+	defer upstream.Close()
+
+	logger, err := logging.New(logging.Config{Level: "debug"})
+	if err != nil {
+		t.Fatalf("logger init failed: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = logger.Close()
+	})
+
+	cfg := config.Default()
+	cfg.Proxy.Enabled = true
+	cfg.Proxy.Anthropic.BaseURL = upstream.URL
+	cfg.Providers.Anthropic.Key = "anthropic-test-key"
+
+	proxy := NewAnthropicProxy(cfg, logger, &captureStore{})
+	_, err = proxy.Forward(context.Background(), ForwardRequest{
+		Payload:   []byte(`{"model":"claude-3-5-sonnet","messages":[]}`),
+		RequestID: "req-upstream-oversized",
+	})
+	if qerrors.CodeOf(err) != qerrors.CodeProxyUpstreamError {
+		t.Fatalf("expected PROXY_UPSTREAM_ERROR, got %v", qerrors.CodeOf(err))
+	}
+
+	status := proxy.Status()
+	if status.LastUpstreamCode == nil || *status.LastUpstreamCode != http.StatusOK {
+		t.Fatalf("expected last upstream status 200 in diagnostics")
+	}
+}
+
 func TestAnthropicProxyMapsTimeout(t *testing.T) {
 	t.Parallel()
 

--- a/internal/proxy/api/anthropic_proxy_test.go
+++ b/internal/proxy/api/anthropic_proxy_test.go
@@ -252,6 +252,59 @@ func TestAnthropicProxyMapsUpstreamClientErrorToValidation(t *testing.T) {
 	}
 }
 
+func TestProxyErrorFromUpstreamStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		status   int
+		expected qerrors.Code
+	}{
+		{
+			name:     "bad request maps to validation",
+			status:   http.StatusBadRequest,
+			expected: qerrors.CodeValidationFailed,
+		},
+		{
+			name:     "unprocessable entity maps to validation",
+			status:   http.StatusUnprocessableEntity,
+			expected: qerrors.CodeValidationFailed,
+		},
+		{
+			name:     "unauthorized stays upstream error",
+			status:   http.StatusUnauthorized,
+			expected: qerrors.CodeProxyUpstreamError,
+		},
+		{
+			name:     "forbidden stays upstream error",
+			status:   http.StatusForbidden,
+			expected: qerrors.CodeProxyUpstreamError,
+		},
+		{
+			name:     "rate limited stays upstream error",
+			status:   http.StatusTooManyRequests,
+			expected: qerrors.CodeProxyUpstreamError,
+		},
+		{
+			name:     "server error stays upstream error",
+			status:   http.StatusBadGateway,
+			expected: qerrors.CodeProxyUpstreamError,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := proxyErrorFromUpstreamStatus(tc.status)
+			if qerrors.CodeOf(err) != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, qerrors.CodeOf(err))
+			}
+		})
+	}
+}
+
 func TestAnthropicProxyFailsOnOversizedUpstreamBody(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- cap Anthropic upstream response buffering to prevent unbounded memory growth in proxy forwarding
- map upstream provider `4xx` to `VALIDATION_FAILED` (HTTP 400) instead of `PROXY_UPSTREAM_ERROR` (HTTP 502)
- add tests for upstream `400` mapping and oversized upstream response handling
- update OpenAPI `400` description for proxy endpoint to include upstream client-side rejection

## Validation

- `go test ./...`
- `golangci-lint run ./...`

## Linkage

Follow-up for #15 (review comments)
Related to #2
